### PR TITLE
Update QueryableExtensions.cs

### DIFF
--- a/src/AutoMapper/QueryableExtensions.cs
+++ b/src/AutoMapper/QueryableExtensions.cs
@@ -157,6 +157,14 @@ namespace AutoMapper.QueryableExtensions
                     var transformedExpression = CreateMapExpression(mappingEngine, result.Type,
                                                                     propertyMap.DestinationPropertyType,
                                                                     result.ResolutionExpression);
+                    
+                    // Handles null source property so it will not create an object with possible non-nullable propeerties 
+                    // which would result in an exception.
+                    if (mappingEngine.ConfigurationProvider.MapNullSourceValuesAsNull)
+                    {
+                        var expressionNull = Expression.Constant(null, propertyMap.DestinationPropertyType);
+                        transformedExpression = Expression.Condition(Expression.NotEqual(result.ResolutionExpression, Expression.Constant(null)), transformedExpression, expressionNull);
+                    }
 
                     bindExpression = Expression.Bind(destinationMember, transformedExpression);
                 }


### PR DESCRIPTION
Handles null source property in queryable extensions so it will not create an object with possible non-nullable properties which would result in an exception during to attempt to set them to null by Linq-to-Sql engine or whatever.
