### PR TITLE
Show extensions of ValueTransformerConfiguration

### DIFF
--- a/src/AutoMapper/Configuration/IProfileConfiguration.cs
+++ b/src/AutoMapper/Configuration/IProfileConfiguration.cs
@@ -44,6 +44,6 @@ namespace AutoMapper.Configuration
         INamingConvention DestinationMemberNamingConvention { get; }
         IEnumerable<ITypeMapConfiguration> TypeMapConfigs { get; }
         IEnumerable<ITypeMapConfiguration> OpenTypeMapConfigs { get; }
-        IEnumerable<ValueTransformerConfiguration> ValueTransformers { get; }
+        IEnumerable<IValueTransformConfiguration> ValueTransformers { get; }
     }
 }

--- a/src/AutoMapper/Configuration/MappingExpression.cs
+++ b/src/AutoMapper/Configuration/MappingExpression.cs
@@ -156,7 +156,7 @@ namespace AutoMapper.Configuration
         public Type DestinationType => Types.DestinationType;
         public bool IsOpenGeneric { get; }
         public ITypeMapConfiguration ReverseTypeMap => _reverseMap;
-        protected List<Action<TypeMap>> TypeMapActions { get; } = new List<Action<TypeMap>>();
+        public List<Action<TypeMap>> TypeMapActions { get; } = new List<Action<TypeMap>>();
 
         public IMappingExpression<TSource, TDestination> PreserveReferences()
         {
@@ -530,17 +530,7 @@ namespace AutoMapper.Configuration
             return this;
         }
 
-        public IMappingExpression<TSource, TDestination> ApplyTransform<TValue>(Expression<Func<TValue, TValue>> transformer)
-        {
-            TypeMapActions.Add(tm =>
-            {
-                var config = new ValueTransformerConfiguration(typeof(TValue), transformer);
-
-                tm.AddValueTransformation(config);
-            });
-
-            return this;
-        }
+        
 
         private IPropertyMapConfiguration GetDestinationMemberConfiguration(MemberInfo destinationMember) =>
             _memberConfigurations.FirstOrDefault(m => m.DestinationMember == destinationMember);

--- a/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
@@ -13,7 +13,7 @@ namespace AutoMapper.Configuration
         private readonly MemberInfo _destinationMember;
         private LambdaExpression _sourceMember;
         private readonly Type _sourceType;
-        protected List<Action<PropertyMap>> PropertyMapActions { get; } = new List<Action<PropertyMap>>();
+        public List<Action<PropertyMap>> PropertyMapActions { get; } = new List<Action<PropertyMap>>();
 
         public MemberConfigurationExpression(MemberInfo destinationMember, Type sourceType)
         {
@@ -230,16 +230,6 @@ namespace AutoMapper.Configuration
                     (src, ctxt) => condition(src, ctxt);
 
                 pm.PreCondition = expr;
-            });
-        }
-
-        public void ApplyTransform<TValue>(Expression<Func<TValue, TValue>> transformer)
-        {
-            PropertyMapActions.Add(pm =>
-            {
-                var config = new ValueTransformerConfiguration(typeof(TValue), transformer);
-
-                pm.AddValueTransformation(config);
             });
         }
 

--- a/src/AutoMapper/IMappingExpression.cs
+++ b/src/AutoMapper/IMappingExpression.cs
@@ -1,12 +1,17 @@
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 
 namespace AutoMapper
 {
+    public interface IMappingExpressionBase
+    {
+        List<Action<TypeMap>> TypeMapActions { get; }
+    }
     /// <summary>
     /// Mapping configuration options for non-generic maps
     /// </summary>
-    public interface IMappingExpression
+    public interface IMappingExpression : IMappingExpressionBase
     {
         /// <summary>
         /// Preserve object identity. Useful for circular references.
@@ -188,7 +193,7 @@ namespace AutoMapper
     /// </summary>
     /// <typeparam name="TSource">Source type</typeparam>
     /// <typeparam name="TDestination">Destination type</typeparam>
-    public interface IMappingExpression<TSource, TDestination>
+    public interface IMappingExpression<TSource, TDestination> : IMappingExpressionBase
     {
         /// <summary>
         /// Customize configuration for a path inside the destination object.
@@ -439,13 +444,5 @@ namespace AutoMapper
         /// </summary>
         /// <returns>Itself</returns>
         IMappingExpression<TSource, TDestination> DisableCtorValidation();
-
-        /// <summary>
-        /// Apply a transformation function after any resolved destination member value with the given type
-        /// </summary>
-        /// <typeparam name="TValue">Value type to match and transform</typeparam>
-        /// <param name="transformer">Transformation expression</param>
-        /// <returns>Itself</returns>
-        IMappingExpression<TSource, TDestination> ApplyTransform<TValue>(Expression<Func<TValue, TValue>> transformer);
     }
 }

--- a/src/AutoMapper/IMemberConfigurationExpression.cs
+++ b/src/AutoMapper/IMemberConfigurationExpression.cs
@@ -1,16 +1,22 @@
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 
 namespace AutoMapper
 {
+    public interface IMemberConfigurationExpressionBase
+    {
+        List<Action<PropertyMap>> PropertyMapActions { get; }
+    }
+
     /// <summary>
     /// Member configuration options
     /// </summary>
     /// <typeparam name="TSource">Source type for this member</typeparam>
     /// <typeparam name="TMember">Type for this member</typeparam>
     /// <typeparam name="TDestination">Destination type for this map</typeparam>
-    public interface IMemberConfigurationExpression<TSource, TDestination, TMember>
+    public interface IMemberConfigurationExpression<TSource, TDestination, TMember> : IMemberConfigurationExpressionBase
     {
         /// <summary>
         /// Do not precompute the execution plan for this member, just map it at runtime.
@@ -199,13 +205,6 @@ namespace AutoMapper
         /// The destination member being configured.
         /// </summary>
         MemberInfo DestinationMember { get; }
-
-        /// <summary>
-        /// Apply a transformation function after any resolved destination member value with the given type
-        /// </summary>
-        /// <typeparam name="TValue">Value type to match and transform</typeparam>
-        /// <param name="transformer">Transformation expression</param>
-        void ApplyTransform<TValue>(Expression<Func<TValue, TValue>> transformer);
     }
 
     /// <summary>

--- a/src/AutoMapper/IObjectMapper.cs
+++ b/src/AutoMapper/IObjectMapper.cs
@@ -63,8 +63,8 @@ namespace AutoMapper
             Call(
                 Constant(this),
                 MapMethod,
-                ToType(sourceExpression, typeof(TSource)),
-                ToType(destExpression, typeof(TDestination)),
+                sourceExpression.ToType(typeof(TSource)),
+                destExpression.ToType(typeof(TDestination)),
                 contextExpression);
     }
 }

--- a/src/AutoMapper/IProfileExpression.cs
+++ b/src/AutoMapper/IProfileExpression.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Linq.Expressions;
+using System.Collections.Generic;
 using System.Reflection;
 using AutoMapper.Configuration.Conventions;
 using AutoMapper.Mappers;
@@ -154,11 +154,6 @@ namespace AutoMapper
         /// <param name="type">Static type that contains extension methods</param>
         void IncludeSourceExtensionMethods(Type type);
 
-        /// <summary>
-        /// Apply a transformation function after any resolved destination member value with the given type
-        /// </summary>
-        /// <typeparam name="TValue">Value type to match and transform</typeparam>
-        /// <param name="transformer">Transformation expression</param>
-        void ApplyTransform<TValue>(Expression<Func<TValue, TValue>> transformer);
+        IList<IValueTransformConfiguration> ValueTransformers { get; }
     }
 }

--- a/src/AutoMapper/IValueTransformConfiguration.cs
+++ b/src/AutoMapper/IValueTransformConfiguration.cs
@@ -1,0 +1,10 @@
+using System.Linq.Expressions;
+
+namespace AutoMapper
+{
+    public interface IValueTransformConfiguration
+    {
+        bool IsMatch(PropertyMap propertyMap);
+        Expression Visit(Expression current, PropertyMap propertyMap);
+    }
+}

--- a/src/AutoMapper/Internal/ExpressionFactory.cs
+++ b/src/AutoMapper/Internal/ExpressionFactory.cs
@@ -88,7 +88,7 @@ namespace AutoMapper.Internal
                 ? expression 
                 : Expression.Convert(expression, typeof(object));
 
-        public static Expression ToType(Expression expression, Type type) => 
+        public static Expression ToType(this Expression expression, Type type) => 
             expression.Type == type 
                 ? expression 
             : Expression.Convert(expression, type);

--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -127,11 +127,11 @@ namespace AutoMapper
                 var requestedDestinationParameter = Parameter(requestedDestinationType, "typeMapDestination");
                 var contextParameter = Parameter(typeof(ResolutionContext), "context");
 
-                mapExpression = Lambda(ToType(Invoke(typeMap.MapExpression,
-                    ToType(requestedSourceParameter, typeMapSourceParameter.Type),
-                    ToType(requestedDestinationParameter, typeMapDestinationParameter.Type),
+                mapExpression = Lambda(Invoke(typeMap.MapExpression,
+                    requestedSourceParameter.ToType(typeMapSourceParameter.Type),
+                    requestedDestinationParameter.ToType(typeMapDestinationParameter.Type),
                     contextParameter
-                    ), mapRequest.RuntimeTypes.DestinationType),
+                    ).ToType(mapRequest.RuntimeTypes.DestinationType),
                     requestedSourceParameter, requestedDestinationParameter, contextParameter);
             }
 
@@ -154,12 +154,12 @@ namespace AutoMapper
             else
             {
                 var map = mapperToUse.MapExpression(mapperConfiguration, Configuration, null, 
-                                                                        ToType(source, mapRequest.RuntimeTypes.SourceType), 
-                                                                        ToType(destination, mapRequest.RuntimeTypes.DestinationType), 
+                                                                        source.ToType(mapRequest.RuntimeTypes.SourceType), 
+                                                                        destination.ToType(mapRequest.RuntimeTypes.DestinationType), 
                                                                         context);
                 var exception = Parameter(typeof(Exception), "ex");
                 fullExpression =
-                    TryCatch(ToType(map, destinationType),
+                    TryCatch(map.ToType(destinationType),
                     MakeCatchBlock(typeof(Exception), exception, Block(
                         Throw(New(ExceptionConstructor, Constant("Error mapping types."), exception, Constant(mapRequest.RequestedTypes))),
                         Default(destination.Type)), null));
@@ -389,9 +389,7 @@ namespace AutoMapper
                 var destination = requestedDestinationType.IsValueType() ? Coalesce(destinationParameter, New(requestedDestinationType)) : (Expression)destinationParameter;
                 // Invoking a delegate here
                 return Lambda<UntypedMapperFunc>(
-                            ToType(
-                                Invoke(typedExpression, ToType(sourceParameter, requestedSourceType), ToType(destination, requestedDestinationType), contextParameter)
-                                , typeof(object)),
+                                Invoke(typedExpression, sourceParameter.ToType(requestedSourceType), destination.ToType(requestedDestinationType), contextParameter).ToType(typeof(object)),
                           sourceParameter, destinationParameter, contextParameter);
             }
         }

--- a/src/AutoMapper/Mappers/EnumToUnderlyingTypeMapper.cs
+++ b/src/AutoMapper/Mappers/EnumToUnderlyingTypeMapper.cs
@@ -24,11 +24,6 @@ namespace AutoMapper.Mappers
         public Expression MapExpression(IConfigurationProvider configurationProvider, ProfileMap profileMap,
             PropertyMap propertyMap, Expression sourceExpression, Expression destExpression,
             Expression contextExpression) =>
-                ToType(
-                    Call(ChangeTypeMethod, ToObject(sourceExpression),
-                        Constant(destExpression.Type)),
-                    destExpression.Type
-                );
+                Call(ChangeTypeMethod, ToObject(sourceExpression),Constant(destExpression.Type)).ToType(destExpression.Type);
     }
-    
 }

--- a/src/AutoMapper/Mappers/FlagsEnumMapper.cs
+++ b/src/AutoMapper/Mappers/FlagsEnumMapper.cs
@@ -28,13 +28,10 @@ namespace AutoMapper.Mappers
         public Expression MapExpression(IConfigurationProvider configurationProvider, ProfileMap profileMap,
             PropertyMap propertyMap, Expression sourceExpression, Expression destExpression,
             Expression contextExpression) =>
-                ToType(
                     Call(EnumParseMethod,
                         Constant(destExpression.Type),
                         Call(sourceExpression, sourceExpression.Type.GetDeclaredMethod("ToString")),
                         Constant(true)
-                    ),
-                    destExpression.Type
-                );
+                    ).ToType(destExpression.Type);
     }
 }

--- a/src/AutoMapper/Mappers/FromDynamicMapper.cs
+++ b/src/AutoMapper/Mappers/FromDynamicMapper.cs
@@ -53,9 +53,8 @@ namespace AutoMapper.Mappers
             Call(null,
                 MapMethodInfo.MakeGenericMethod(sourceExpression.Type, destExpression.Type),
                 sourceExpression,
-                ToType(
                     Coalesce(ToObject(destExpression),
-                        DelegateFactory.GenerateConstructorExpression(destExpression.Type)), destExpression.Type),
+                        DelegateFactory.GenerateConstructorExpression(destExpression.Type)).ToType(destExpression.Type),
                 contextExpression,
                 Constant(profileMap));
     }

--- a/src/AutoMapper/Mappers/Internal/CollectionMapperExpressionFactory.cs
+++ b/src/AutoMapper/Mappers/Internal/CollectionMapperExpressionFactory.cs
@@ -45,7 +45,7 @@ namespace AutoMapper.Mappers.Internal
                     IfThenElse(condition ?? Constant(false),
                         Block(Assign(newExpression, passedDestination), Call(newExpression, clearMethod)),
                         Assign(newExpression, passedDestination.Type.NewExpr(ifInterfaceType))),
-                    ToType(mapExpr, passedDestination.Type)
+                    mapExpr.ToType(passedDestination.Type)
                 );
             if (propertyMap != null)
                 return checkNull;
@@ -65,7 +65,7 @@ namespace AutoMapper.Mappers.Internal
                     ifInterfaceType.MakeGenericType(ElementTypeHelper.GetElementTypes(baseType,
                         ElementTypeFlags.BreakKeyValuePair)))
                 : DelegateFactory.GenerateConstructorExpression(baseType);
-            return ToType(newExpr, baseType);
+            return newExpr.ToType(baseType);
         }
 
         public static Expression MapItemExpr(IConfigurationProvider configurationProvider, ProfileMap profileMap, PropertyMap propertyMap, Type sourceType, Type destType, Expression contextParam, out ParameterExpression itemParam)
@@ -78,7 +78,7 @@ namespace AutoMapper.Mappers.Internal
 
             var itemExpr = MapExpression(configurationProvider, profileMap, typePair, itemParam, contextParam,
                 propertyMap);
-            return ToType(itemExpr, destElementType);
+            return itemExpr.ToType(destElementType);
         }
 
         public static Expression MapKeyPairValueExpr(IConfigurationProvider configurationProvider, ProfileMap profileMap, PropertyMap propertyMap, Type sourceType, Type destType, Expression contextParam, out ParameterExpression itemParam)

--- a/src/AutoMapper/Mappers/StringToEnumMapper.cs
+++ b/src/AutoMapper/Mappers/StringToEnumMapper.cs
@@ -32,15 +32,14 @@ namespace AutoMapper.Mappers
                 if (attribute?.Value != null)
                 {
                     var switchCase = Expression.SwitchCase(
-                        ToType(Expression.Constant(Enum.ToObject(destinationEnumType, memberInfo.GetMemberValue(null))),
-                            destinationType), Expression.Constant(attribute.Value));
+                        Expression.Constant(Enum.ToObject(destinationEnumType, memberInfo.GetMemberValue(null))).ToType(destinationType), Expression.Constant(attribute.Value));
                     switchCases.Add(switchCase);
                 }
             }
             var equalsMethodInfo = Method(() => StringCompareOrdinalIgnoreCase(null, null));
             var switchTable = switchCases.Count > 0
-                ? Expression.Switch(sourceExpression, ToType(enumParse, destinationType), equalsMethodInfo, switchCases)
-                : ToType(enumParse, destinationType);
+                ? Expression.Switch(sourceExpression, enumParse.ToType(destinationType), equalsMethodInfo, switchCases)
+                : enumParse.ToType(destinationType);
             var isNullOrEmpty = Expression.Call(typeof(string), "IsNullOrEmpty", null, sourceExpression);
             return Expression.Condition(isNullOrEmpty, Expression.Default(destinationType), switchTable);
         }

--- a/src/AutoMapper/Mappers/ToDynamicMapper.cs
+++ b/src/AutoMapper/Mappers/ToDynamicMapper.cs
@@ -55,9 +55,8 @@ namespace AutoMapper.Mappers
             Call(null,
                 MapMethodInfo.MakeGenericMethod(sourceExpression.Type, destExpression.Type),
                 sourceExpression,
-                ToType(
                     Coalesce(ToObject(destExpression),
-                        DelegateFactory.GenerateConstructorExpression(destExpression.Type)), destExpression.Type),
+                        DelegateFactory.GenerateConstructorExpression(destExpression.Type)).ToType(destExpression.Type),
                 contextExpression,
                 Constant(profileMap));
     }

--- a/src/AutoMapper/Mappers/UnderlyingTypeToEnumMapper.cs
+++ b/src/AutoMapper/Mappers/UnderlyingTypeToEnumMapper.cs
@@ -23,10 +23,7 @@ namespace AutoMapper.Mappers
         public Expression MapExpression(IConfigurationProvider configurationProvider, ProfileMap profileMap,
             PropertyMap propertyMap, Expression sourceExpression, Expression destExpression,
             Expression contextExpression) =>
-                ToType(
                     Call(EnumToObject, Constant(destExpression.Type),
-                        ToObject(sourceExpression)),
-                    destExpression.Type
-                );
+                        ToObject(sourceExpression)).ToType(destExpression.Type);
     }
 }

--- a/src/AutoMapper/Profile.cs
+++ b/src/AutoMapper/Profile.cs
@@ -27,7 +27,7 @@ namespace AutoMapper
         private readonly List<MethodInfo> _sourceExtensionMethods = new List<MethodInfo>();
         private readonly IList<ConditionalObjectMapper> _typeConfigurations = new List<ConditionalObjectMapper>();
         private readonly List<ITypeMapConfiguration> _typeMapConfigs = new List<ITypeMapConfiguration>();
-        private readonly List<ValueTransformerConfiguration> _valueTransformerConfigs = new List<ValueTransformerConfiguration>();
+        private readonly List<IValueTransformConfiguration> _valueTransformerConfigs = new List<IValueTransformConfiguration>();
 
         protected Profile(string profileName)
             : this() => ProfileName = profileName;
@@ -64,7 +64,8 @@ namespace AutoMapper
         IEnumerable<IConditionalObjectMapper> IProfileConfiguration.TypeConfigurations => _typeConfigurations;
         IEnumerable<ITypeMapConfiguration> IProfileConfiguration.TypeMapConfigs => _typeMapConfigs;
         IEnumerable<ITypeMapConfiguration> IProfileConfiguration.OpenTypeMapConfigs => _openTypeMapConfigs;
-        IEnumerable<ValueTransformerConfiguration> IProfileConfiguration.ValueTransformers => _valueTransformerConfigs;
+        IEnumerable<IValueTransformConfiguration> IProfileConfiguration.ValueTransformers => _valueTransformerConfigs;
+        IList<IValueTransformConfiguration> IProfileExpression.ValueTransformers => _valueTransformerConfigs;
 
         public virtual string ProfileName { get; }
 
@@ -182,13 +183,6 @@ namespace AutoMapper
                         m =>
                             m.IsStatic && m.IsDefined(typeof(ExtensionAttribute), false) &&
                             m.GetParameters().Length == 1));
-        }
-
-        public void ApplyTransform<TValue>(Expression<Func<TValue, TValue>> transformer)
-        {
-            var config = new ValueTransformerConfiguration(typeof(TValue), transformer);
-
-            _valueTransformerConfigs.Add(config);
         }
 
         private IMappingExpression<TSource, TDestination> CreateMappingExpression<TSource, TDestination>(

--- a/src/AutoMapper/ProfileMap.cs
+++ b/src/AutoMapper/ProfileMap.cs
@@ -47,7 +47,7 @@ namespace AutoMapper
                     : Enumerable.Empty<IConditionalObjectMapper>())
                 .ToArray();
 
-            ValueTransformers = profile.ValueTransformers.Concat(configuration?.ValueTransformers ?? Enumerable.Empty<ValueTransformerConfiguration>()).ToArray();
+            ValueTransformers = profile.ValueTransformers.Concat(configuration?.ValueTransformers ?? Enumerable.Empty<IValueTransformConfiguration>()).ToArray();
 
             MemberConfigurations = profile.MemberConfigurations.ToArray();
 
@@ -96,7 +96,7 @@ namespace AutoMapper
         public IEnumerable<IConditionalObjectMapper> TypeConfigurations { get; }
         public IEnumerable<string> Prefixes { get; }
         public IEnumerable<string> Postfixes { get; }
-        public IEnumerable<ValueTransformerConfiguration> ValueTransformers { get; }
+        public IEnumerable<IValueTransformConfiguration> ValueTransformers { get; }
 
         public TypeDetails CreateTypeDetails(Type type) => _typeDetails.GetOrAdd(type);
 

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -17,7 +17,7 @@ namespace AutoMapper
     public class PropertyMap
     {
         private readonly List<MemberInfo> _memberChain = new List<MemberInfo>();
-        private readonly List<ValueTransformerConfiguration> _valueTransformerConfigs = new List<ValueTransformerConfiguration>();
+        private readonly List<IValueTransformConfiguration> _valueTransformerConfigs = new List<IValueTransformConfiguration>();
 
         public PropertyMap(PathMap pathMap)
         {
@@ -69,7 +69,7 @@ namespace AutoMapper
         public bool ExplicitExpansion { get; set; }
         public object NullSubstitute { get; set; }
         public ValueResolverConfiguration ValueResolverConfig { get; set; }
-        public IEnumerable<ValueTransformerConfiguration> ValueTransformers => _valueTransformerConfigs;
+        public IEnumerable<IValueTransformConfiguration> ValueTransformers => _valueTransformerConfigs;
 
         public MemberInfo SourceMember
         {
@@ -144,7 +144,7 @@ namespace AutoMapper
             Ignored = false;
         }
 
-        public void AddValueTransformation(ValueTransformerConfiguration valueTransformerConfiguration)
+        public void AddValueTransformation(IValueTransformConfiguration valueTransformerConfiguration)
         {
             _valueTransformerConfigs.Add(valueTransformerConfiguration);
         }

--- a/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
@@ -300,7 +300,7 @@ namespace AutoMapper.QueryableExtensions
             private Expression NullCheck(Expression input)
             {
                 var underlyingType = input.Type.GetTypeOfNullable();
-                var nullSubstitute = ToType(Constant(_nullSubstitute), underlyingType);
+                var nullSubstitute = Constant(_nullSubstitute).ToType(underlyingType);
                 return Condition(Property(input, "HasValue"), Property(input, "Value"), nullSubstitute, underlyingType);
             }
         }

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -29,7 +29,7 @@ namespace AutoMapper
         private PropertyMap[] _orderedPropertyMaps;
         private bool _sealed;
         private readonly IList<TypeMap> _inheritedTypeMaps = new List<TypeMap>();
-        private readonly List<ValueTransformerConfiguration> _valueTransformerConfigs = new List<ValueTransformerConfiguration>();
+        private readonly List<IValueTransformConfiguration> _valueTransformerConfigs = new List<IValueTransformConfiguration>();
 
         public TypeMap(TypeDetails sourceType, TypeDetails destinationType, MemberList memberList, ProfileMap profile)
         {
@@ -81,7 +81,7 @@ namespace AutoMapper
 
         public IEnumerable<LambdaExpression> BeforeMapActions => _beforeMapActions;
         public IEnumerable<LambdaExpression> AfterMapActions => _afterMapActions;
-        public IEnumerable<ValueTransformerConfiguration> ValueTransformers => _valueTransformerConfigs;
+        public IEnumerable<IValueTransformConfiguration> ValueTransformers => _valueTransformerConfigs;
 
         public bool PreserveReferences { get; set; }
         public LambdaExpression Condition { get; set; }
@@ -261,7 +261,7 @@ namespace AutoMapper
             }
         }
 
-        public void AddValueTransformation(ValueTransformerConfiguration valueTransformerConfiguration)
+        public void AddValueTransformation(IValueTransformConfiguration valueTransformerConfiguration)
         {
             _valueTransformerConfigs.Add(valueTransformerConfiguration);
         }

--- a/src/AutoMapper/ValueTransformerConfiguration.cs
+++ b/src/AutoMapper/ValueTransformerConfiguration.cs
@@ -1,22 +1,81 @@
 using System;
 using System.Linq.Expressions;
+using AutoMapper.Internal;
 
 namespace AutoMapper
 {
-    public class ValueTransformerConfiguration
+    public class ValueTransformConfiguration : IValueTransformConfiguration
     {
-        public ValueTransformerConfiguration(Type valueType, LambdaExpression transformerExpression)
+        public ValueTransformConfiguration(Type valueType, LambdaExpression transformerExpression)
         {
             ValueType = valueType;
             TransformerExpression = transformerExpression;
         }
 
-        public Type ValueType { get; }
-        public LambdaExpression TransformerExpression { get; }
+        private Type ValueType { get; }
+        private LambdaExpression TransformerExpression { get; }
 
         public bool IsMatch(PropertyMap propertyMap)
         {
             return ValueType.IsAssignableFrom(propertyMap.DestinationPropertyType);
+        }
+
+        public Expression Visit(Expression expression, PropertyMap propertyMap)
+        {
+            return TransformerExpression.ReplaceParameters(expression.ToType(ValueType)).ToType(propertyMap.DestinationPropertyType);
+        }
+    }
+
+    public static class ValueTransformerConfigurationExtensions
+    {
+        /// <summary>
+        /// Apply a transformation function after any resolved destination member value with the given type
+        /// </summary>
+        /// <typeparam name="TValue">Value type to match and transform</typeparam>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="mappingExpression"></param>
+        /// <param name="transformer">Transformation expression</param>
+        /// <returns>Itself</returns>
+        public static T ApplyTransform<T, TValue>(this T mappingExpression, Expression<Func<TValue, TValue>> transformer)
+            where T : IMappingExpressionBase
+        {
+            mappingExpression.TypeMapActions.Add(tm =>
+            {
+                var config = new ValueTransformConfiguration(typeof(TValue), transformer);
+
+                tm.AddValueTransformation(config);
+            });
+
+            return mappingExpression;
+        }
+
+        /// <summary>
+        /// Apply a transformation function after any resolved destination member value with the given type
+        /// </summary>
+        /// <typeparam name="TValue">Value type to match and transform</typeparam>
+        /// <param name="profileExpression"></param>
+        /// <param name="transformer">Transformation expression</param>
+        public static void ApplyTransform<TValue>(this IProfileExpression profileExpression, Expression<Func<TValue, TValue>> transformer)
+        {
+            var config = new ValueTransformConfiguration(typeof(TValue), transformer);
+
+            profileExpression.ValueTransformers.Add(config);
+        }
+
+        /// <summary>
+        /// Apply a transformation function after any resolved destination member value with the given type
+        /// </summary>
+        /// <typeparam name="TValue">Value type to match and transform</typeparam>
+        /// <param name="self"></param>
+        /// <param name="transformer">Transformation expression</param>
+        public static void ApplyTransform<TValue>(this IMemberConfigurationExpressionBase self, Expression<Func<TValue, TValue>> transformer)
+        {
+            self.PropertyMapActions.Add(pm =>
+            {
+                var config = new ValueTransformConfiguration(typeof(TValue), transformer);
+
+                pm.AddValueTransformation(config);
+            });
         }
     }
 }

--- a/src/UnitTests/ValueTransformers.cs
+++ b/src/UnitTests/ValueTransformers.cs
@@ -188,7 +188,7 @@ namespace AutoMapper.UnitTests
                 cfg.CreateProfile("Other", p =>
                 {
                     p.CreateMap<Source, Dest>()
-                     .ApplyTransform<string>(dest => dest + ", for real,");
+                     .ApplyTransform<IMappingExpression<Source,Dest>, string>(dest => dest + ", for real,");
                     p.ApplyTransform<string>(dest => dest + " is straight up dope");
                 });
             });
@@ -224,7 +224,7 @@ namespace AutoMapper.UnitTests
                 cfg.CreateProfile("Other", p =>
                 {
                     p.CreateMap<Source, Dest>()
-                     .ApplyTransform<string>(dest => dest + ", for real,")
+                     .ApplyTransform<IMappingExpression<Source, Dest>, string>(dest => dest + ", for real,")
                      .ForMember(d => d.Value, opt => opt.ApplyTransform<string>(d => d + ", seriously"));
                     p.ApplyTransform<string>(dest => dest + " is straight up dope");
                 });


### PR DESCRIPTION
Main change to look at is in ValueTransformerConfiguration.cs file.  Other changes were trying to get this to work with the ToType to extension method thing.

So idea is can make own implementations and can add them using extension methods.  That way you aren't limited to `ApplyTransform<T>` and can't do more sophisticated filtered transforms.

Other way is remove the interface and have ValueTransformerConfiguration have `Func<object,bool>` or something along those lines.  Then have the extension methods of ApplyTransform ValueTransformerConfigurationExtensions passing in different kinds of Functions into the constructor.

If there's like 3+ different version of ApplyTransform that would be 9+ ApplyTransform functions that would need to be generated.  It would be a lot easier to maintain and see what they are if they were all in a single class close to the implementation of it.  Instead of having to update the Interfaces and Implementations of 4-6 classes per new function generated (18+ functions in 6 files).

`IMappingExpression<TSource, TDestination>` doesn't work well with this and I don't know how to ignore adding the types explicitly for Generics, but the point was to show what it would look like if you were to do something like this.
